### PR TITLE
🔧 Reconfigure Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch",
+      "requiredStatusChecks": null
     }
   ],
   "extends": [


### PR DESCRIPTION
* Set Renovate to use branch instead of PR for minor, patch, pin and digest dependencies
* Disable tests for these dependencies
